### PR TITLE
Allow to modify 'User:' tag for localization and others

### DIFF
--- a/Tfs2Git.ps1
+++ b/Tfs2Git.ps1
@@ -17,7 +17,8 @@ Param
 	[string]$WorkspaceName = "TFS2GIT",
 	[int]$StartingCommit,
 	[int]$EndingCommit,
-	[string]$UserMappingFile
+	[string]$UserMappingFile,
+	[string]$UserTagName = "User"
 )
 
 function CheckPath([string]$program) 
@@ -248,7 +249,9 @@ function Convert ([array]$ChangeSets)
 		git rm $CommitMessageFileName --cached --force		
 
 		$CommitMsg = Get-Content $CommitMessageFileName		
-		$Match = ([regex]'User: (\w+)').Match($commitMsg)
+		# Username in 'User:' tag may contain '-' or '\' in some environment. (ex. 'computername\username')
+		$Pattern = $UserTagName + ': ([\w\\\-]+)' 
+		$Match = ([regex]$Pattern).Match($commitMsg)
 		if ($UserMapping.Count -gt 0 -and $Match.Success -and $UserMapping.ContainsKey($Match.Groups[1].Value)) 
 		{	
 			$Author = $userMapping[$Match.Groups[1].Value]
@@ -308,7 +311,9 @@ function CleanUp
 # This is where all the fun starts...
 function Main
 {
-	CheckPath("git.cmd")
+	# Early version of msysgit had 'git.cmd' but recent version of it replaced to 'git.exe'.
+	# Therefore we can use 'git' without extention. This should be enougth for us.
+	CheckPath("git")
 	CheckPath("tf.exe")
 	CheckParameters
 	PrepareWorkspace


### PR DESCRIPTION
Mr. Wilbert van Dolleweerd

I am Japanese software engineer which is using dodox86 as handle.
Now I am trying to use your tool for our tfs repository.
I think this tool is very useful. I was looking for such tool.

While I was trying to use this, I wrote some modification for our environment.
Because I am using Japanese Windows. I encountered some/little problems with original code.

I send these modification to you via pull request.
I hope to accept them if you can.

This is the first time to pull request on github.
  So please forgive me if there is something rude.

Thank you in advance.

--- Following are commit message:
Allow to modify 'User:' tag for localization and others

(1) tf.exe shows other text for 'User:' tagname in Non-English windows environment.
It can modify to other text when specify commandline option -UserTagName 'tagname you want'.

(2) Username of tf.exe history message may contain not only standard word
   but also '-' or '\\' in some environment.
ex. "User: machine-dev\username"

(3) "git.cmd" does not contain in recent version of msysgit.
   Currently we should use "git.exe". However just "git" is enough for application path.
