### PR TITLE
Allow to modify 'User:' tag for localization and others

### DIFF
--- a/Tfs2Git.ps1
+++ b/Tfs2Git.ps1
@@ -155,7 +155,7 @@ function ApplyCheckinDate([string]$commitMessageFileName, [string]$author)
 		return
 	}
 
-    $pattern = "^" + $DateTagName + ": (.*)\s*$"    
+    $pattern = "^" + $DateTagName + ": (.*)\s*$"
 	Get-Content $commitMessageFileName | foreach {
 		# Retrieve the value in Date: tag.
 		$m = [regex]::Match($_, $pattern)
@@ -166,7 +166,8 @@ function ApplyCheckinDate([string]$commitMessageFileName, [string]$author)
 			{
 				$date = [DateTime]::Parse($text)
 				$gitDate = $date.ToString("yyyy-MM-dd HH:mm:ss")
-				$Env:GIT_COMMITTER_DATE="$gitDate" 
+				$orig = $Env:GIT_COMMITTER_DATE
+				$Env:GIT_COMMITTER_DATE = "$gitDate" 
 				if ($author)
 				{
 					# $author is specified.
@@ -176,6 +177,8 @@ function ApplyCheckinDate([string]$commitMessageFileName, [string]$author)
 				{
 					git commit --amend --date $gitDate --file $CommitMessageFileName | Out-Null									
 				}
+
+				$Env:GIT_COMMITTER_DATE = $pre
 			}
 			return
 		}

--- a/Tfs2Git.ps1
+++ b/Tfs2Git.ps1
@@ -17,7 +17,8 @@ Param
 	[string]$WorkspaceName = "TFS2GIT",
 	[int]$StartingCommit,
 	[int]$EndingCommit,
-	[string]$UserMappingFile
+	[string]$UserMappingFile,
+	[string]$UserTagName = "User"
 )
 
 function CheckPath([string]$program) 
@@ -248,7 +249,9 @@ function Convert ([array]$ChangeSets)
 		git rm $CommitMessageFileName --cached --force		
 
 		$CommitMsg = Get-Content $CommitMessageFileName		
-		$Match = ([regex]'User: (\w+)').Match($commitMsg)
+		# Username in 'User:' tag may contain '-' or '\' in some environment. (ex. 'computername\username')
+		$Pattern = $UserTagName + ': ([\w\\\-]+)' 
+		$Match = ([regex]$Pattern).Match($commitMsg)
 		if ($UserMapping.Count -gt 0 -and $Match.Success -and $UserMapping.ContainsKey($Match.Groups[1].Value)) 
 		{	
 			$Author = $userMapping[$Match.Groups[1].Value]
@@ -308,7 +311,9 @@ function CleanUp
 # This is where all the fun starts...
 function Main
 {
-	CheckPath("git.cmd")
+	# Early version of msysgit had 'git.cmd' but recent version of it replaced to 'git.exe'.
+	# Therefore we can use 'git' without extention. This should be enougth for us.
+	CheckPath("git")
 	CheckPath("tf.exe")
 	CheckParameters
 	PrepareWorkspace


### PR DESCRIPTION
(1) tf.exe shows other text for 'User:' tagname in Non-English windows environment.
It can modify to other text when specify commandline option -UserTagName 'tagname you want'.

(2) Username of tf.exe history message may contain not only standard word
   but also '-' or '\\' in some environment.
ex. "User: machine-dev\username"

(3) "git.cmd" does not contain in recent version of msysgit.
   Currently we should use "git.exe". However just "git" is enough for application path.